### PR TITLE
RandomFunction.php : getSql must rerturn string

### DIFF
--- a/DQL/RandomFunction.php
+++ b/DQL/RandomFunction.php
@@ -16,7 +16,7 @@ class RandomFunction extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker) : string
     {
         return 'RANDOM()';
     }


### PR DESCRIPTION
an error with Symfony 7.1 / php 8.3
Compile Error: Declaration of Qbbr\PgsqlDoctrineRandomFunction\DQL\RandomFunction::getSql(Doctrine\ORM\Query\SqlWalker $sqlWalker) must be compatible with Doctrine\ORM\Query\AST\Functions\FunctionNode::getSql(Doctrine\ORM\Query\SqlWalker $sqlWalker): string

